### PR TITLE
Change NZ to Aotearoa NZ in text

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -6,11 +6,11 @@ toc: false
 sidebar: false
 ---
 
-ACEFA aims to support the timely, effective response to epidemic diseases in Australia through real-time data analytics, modelling, and forecasting. Our work builds on a national seasonal influenza forecasting program (2014–19) and [COVID-19 situational assessment consortium (2020–23)](https://doi.org/10.26188/24845328.v1){.external target="_blank"}.
+ACEFA aims to support the timely, effective response to epidemic diseases in Australia and Aotearoa New Zealand through real-time data analytics, modelling, and forecasting. Our work builds on a national seasonal influenza forecasting program (2014–19) and [COVID-19 situational assessment consortium (2020–23)](https://doi.org/10.26188/24845328.v1){.external target="_blank"}.
 
 ### Team
 
-ACEFA involves multiple academic research groups from across Australia and New Zealand, including:
+ACEFA involves multiple academic research groups from across Australia and Aotearoa New Zealand, including:
 
 * [Infectious Disease Dynamics Unit](https://mspgh.unimelb.edu.au/research-groups/centre-for-epidemiology-and-biostatistics-research/infectious-disease-dynamics){.external target="_blank"}, Centre for Epidemiology and Biostatistics Research, The University of Melbourne, Victoria, Australia
 * [Infectious Disease Ecology and Modelling Team](https://www.thekids.org.au/our-research/infectious-diseases/infectious-disease-ecology-and-modelling){.external target="_blank"}, The Kids Research Institute Australia, Western Australia, Australia
@@ -20,7 +20,7 @@ ACEFA involves multiple academic research groups from across Australia and New Z
 * [Infectious Disease Epidemiology and Modelling](https://nceph.anu.edu.au/research/research-groups/infectious-diseases-and-modelling){.external target="_blank"}, National Centre for Epidemiology and Population Health, Australian National University, Canberra, Australia
 * [Infectious diseases modelling and Epidemiology Group](https://www.aithm.jcu.edu.au/professor-emma-mcbryde/){.external target="_blank"}, Australian Institute of Tropical Health and Medicine, James Cook University, Queensland, Australia
 * [Adelaide Data Science Centre](https://set.adelaide.edu.au/adelaide-data-science-centre/){.external target="_blank"}, University of Adelaide, South Australia, Australia
-* [School of Mathematics and Statistics](https://www.canterbury.ac.nz/study/academic-study/engineering/schools-and-departments-engineering-forestry-product-design/school-of-mathematics-and-statistics){.external target="_blank"}, University of Canterbury, New Zealand.
+* [School of Mathematics and Statistics](https://www.canterbury.ac.nz/study/academic-study/engineering/schools-and-departments-engineering-forestry-product-design/school-of-mathematics-and-statistics){.external target="_blank"}, University of Canterbury, Aotearoa New Zealand.
 
 ![](/images/ACEFAlaunchphoto.jpg){fig-alt="ACEFA team at launch event" width=80% fig-align="center"}
 
@@ -29,20 +29,20 @@ ACEFA involves multiple academic research groups from across Australia and New Z
 
 ### Executives
 
-+------------------------------------------+---------------------------------------------------+------------------------------------------+ 
-| **A/Prof Freya Shearer** \               | **Prof Nick Golding** \                           | **Prof Emma McBryde** \                  | 
-| University of Melbourne, Melbourne, VIC\ | The Kids Research Institute Australia, Perth, WA\ | James Cook University, QLD \             | 
-| freya.shearer@unimelb.edu.au \           | \                                                 | \                                        | 
-+------------------------------------------+---------------------------------------------------+------------------------------------------+ 
-| **Prof Michael Plank** \                 | **Prof James Wood** \                             | **Prof James McCaw** \                   | 
-| University of Canterbury, New Zealand\   | University of New South Wales, Sydney, NSW \      | University of Melbourne, Melbourne, VIC\ | 
-+------------------------------------------+---------------------------------------------------+------------------------------------------+ 
-| **Prof. Rob Hyndman** \                  | **Dr Alexandra Hogan** \                          | **Dr Peter Dawson** \                    |
-| Monash University, Melbourne, VIC \      | University of New South Wales, Sydney, NSW\       | Department of Defence \                  |
-+------------------------------------------+---------------------------------------------------+------------------------------------------+ 
-| **Dr David Price** \                     | **Prof Kathryn Glass** \                          | **Dr Andrew Black** \                    | 
-| University of Melbourne, Melbourne, VIC\ | Australian National University, Canberra, ACT\    |  University of Adelaide, Adelaide, SA\   | 
-+------------------------------------------+---------------------------------------------------+------------------------------------------+ 
++---------------------------------------------------+---------------------------------------------------+------------------------------------------+ 
+| **A/Prof Freya Shearer** \                        | **Prof Nick Golding** \                           | **Prof Emma McBryde** \                  | 
+| University of Melbourne, Melbourne, VIC\          | The Kids Research Institute Australia, Perth, WA\ | James Cook University, QLD \             | 
+| freya.shearer@unimelb.edu.au \                    | \                                                 | \                                        | 
++---------------------------------------------------+---------------------------------------------------+------------------------------------------+ 
+| **Prof Michael Plank** \                          | **Prof James Wood** \                             | **Prof James McCaw** \                   | 
+| University of Canterbury, Aotearoa New Zealand\   | University of New South Wales, Sydney, NSW \      | University of Melbourne, Melbourne, VIC\ | 
++---------------------------------------------------+---------------------------------------------------+------------------------------------------+ 
+| **Prof. Rob Hyndman** \                           | **Dr Alexandra Hogan** \                          | **Dr Peter Dawson** \                    |
+| Monash University, Melbourne, VIC \               | University of New South Wales, Sydney, NSW\       | Department of Defence \                  |
++---------------------------------------------------+---------------------------------------------------+------------------------------------------+ 
+| **Dr David Price** \                              | **Prof Kathryn Glass** \                          | **Dr Andrew Black** \                    | 
+| University of Melbourne, Melbourne, VIC\          | Australian National University, Canberra, ACT\    |  University of Adelaide, Adelaide, SA\   | 
++---------------------------------------------------+---------------------------------------------------+------------------------------------------+ 
 
 
 ### Contact Us

--- a/activities/decision-support.qmd
+++ b/activities/decision-support.qmd
@@ -1,6 +1,6 @@
 ---
 title: "**Decision Support**"
-description: "Generate and share real-time analyses with decision-makers in Australia and New Zealand."
+description: "Generate and share real-time analyses with decision-makers in Australia and Aotearoa New Zealand."
 title-block-banner: "#262261"
 title-block-banner-color: white
 image: ../images/vdarkblue-route.png

--- a/activities/scenario-modelling.qmd
+++ b/activities/scenario-modelling.qmd
@@ -11,7 +11,7 @@ sidebar: false
 
 ## Scenario Modelling Pilot Exercise 2025–26
 
-Australian and New Zealand public health partners are interested in assessing the potential population impact of a school-based seasonal influenza immunisation program, using an intranasally delivered live-attenuated influenza vaccine (LAIV).
+Public health partners from Australia and Aotearoa New Zealand are interested in assessing the potential population impact of a school-based seasonal influenza immunisation program, using an intranasally delivered live-attenuated influenza vaccine (LAIV).
 
 **Modelling question:** What are the potential health impacts of a school-based live attenuated influenza vaccination (LAIV) program?
 
@@ -19,7 +19,7 @@ Australian and New Zealand public health partners are interested in assessing th
 
 1.	Provide evidence to support decision-making on the implementation of a school-based LAIV program.  
 
-2.	Establish processes and relationships for multi-model scenario modelling and comparison exercises in Australia and New Zealand, enhancing epidemic preparedness and response.  
+2.	Establish processes and relationships for multi-model scenario modelling and comparison exercises in Australia and Aotearoa New Zealand, enhancing epidemic preparedness and response.  
 
 
 Modelling teams are investigating the potential impact of six LAIV scenarios (B–G) compared to a baseline scenario (A, standard inactivated influenza vaccine administered to all ages).

--- a/activities/winter-assessment.qmd
+++ b/activities/winter-assessment.qmd
@@ -16,7 +16,7 @@ Short-term forecasting of epidemic activity can help to enable rapid understandi
 
 The project has the following aims:
 
-1. To generate real-time epidemic analysis of COVID-19, influenza, and RSV in Australia and New Zealand.
+1. To generate real-time epidemic analysis of COVID-19, influenza, and RSV in Australia and Aotearoa New Zealand.
 
 2. To develop enhanced methods for epidemic situational assessment of viral respiratory pathogens.
 
@@ -25,27 +25,27 @@ The project has the following aims:
 <br>
 <br>
 
-![](/images/Report_Combined.jpg){fig-alt="The cover of two ACEFA reports side by side, with the Australia report number 22 from the 10th of October 2025 on the left and the New Zealand report number 15 from the 3rd of October on the right." width=90% fig-align="center"}
+![](/images/Report_Combined.jpg){fig-alt="The cover of two ACEFA reports side by side, with the Australia report number 22 from the 10th of October 2025 on the left and the Aotearoa New Zealand report number 15 from the 3rd of October on the right." width=90% fig-align="center"}
 
-<p style="text-align: center;color: grey">*Cover page of weekly reports provided to public health partners in Australia and New Zealand during winter months.*</p>
+<p style="text-align: center;color: grey">*Cover page of weekly reports provided to public health partners in Australia and Aotearoa New Zealand during winter months.*</p>
 
 <br>
 <br>
 
-+---------------------------------------------+----------------------------------------------+-------------------------------------------+
-| **Dr Oliver Eales** \                       | **Dr Alec Henderson** \                      | **Dr Rob Moss** \                         |
-| Analyst and Reporting Lead \                | Forecaster \                                 | Forecaster \                              |
-| University of Melbourne, Melbourne, VIC \   | University of Queensland, Brisbane, QLD \    | University of Melbourne, Melbourne, VIC \ |
-| oliver.eales@unimelb.edu.au\                | \                                            | \                                         | 
-+---------------------------------------------+----------------------------------------------+-------------------------------------------+
-| **Dr Adeshina Adekunle** \                  | **Prof Michael Plank** \                     | **Mitchell O’Hara-Wild** \                |
-| Forecaster \                                | Forecaster \                                 | Forecast Evaluation Lead \                |
-| Department of Defence \                     | University of Canterbury, New Zealand \      | Monash University, Melbourne, VIC \       |
-+---------------------------------------------+----------------------------------------------+-------------------------------------------+
-| **Dr Kate Senior** \                        | **Ruarai Tobin** \                           | **Alys Young**\                           |
-| Hub Data Lead \                             | Hub Software Lead \                          | Hub Research Assistant \                  |
-| University of Melbourne, Melbourne, VIC \   | University of Melbourne, Melbourne, VIC \    | University of Melbourne, Melbourne, VIC \ |
-+---------------------------------------------+----------------------------------------------+-------------------------------------------+
++---------------------------------------------+-------------------------------------------------------+-------------------------------------------+
+| **Dr Oliver Eales** \                       | **Dr Alec Henderson** \                               | **Dr Rob Moss** \                         |
+| Analyst and Reporting Lead \                | Forecaster \                                          | Forecaster \                              |
+| University of Melbourne, Melbourne, VIC \   | University of Queensland, Brisbane, QLD \             | University of Melbourne, Melbourne, VIC \ |
+| oliver.eales@unimelb.edu.au\                | \                                                     | \                                         | 
++---------------------------------------------+-------------------------------------------------------+-------------------------------------------+
+| **Dr Adeshina Adekunle** \                  | **Prof Michael Plank** \                              | **Mitchell O’Hara-Wild** \                |
+| Forecaster \                                | Forecaster \                                          | Forecast Evaluation Lead \                |
+| Department of Defence \                     | University of Canterbury, Aotearoa New Zealand \      | Monash University, Melbourne, VIC \       |
++---------------------------------------------+-------------------------------------------------------+-------------------------------------------+
+| **Dr Kate Senior** \                        | **Ruarai Tobin** \                                    | **Alys Young**\                           |
+| Hub Data Lead \                             | Hub Software Lead \                                   | Hub Research Assistant \                  |
+| University of Melbourne, Melbourne, VIC \   | University of Melbourne, Melbourne, VIC \             | University of Melbourne, Melbourne, VIC \ |
++---------------------------------------------+-------------------------------------------------------+-------------------------------------------+
 
 
 <br>

--- a/index.qmd
+++ b/index.qmd
@@ -34,7 +34,7 @@ Australia-Aotearoa Consortium for Epidemic Forecasting & Analytics
 
 <br>
 
-Working to support the timely, effective response to epidemic diseases in Australia and New Zealand through real-time data analytics, modelling, and forecasting.
+Working to support the timely, effective response to epidemic diseases in Australia and Aotearoa New Zealand through real-time data analytics, modelling, and forecasting.
 
 <br>
 


### PR DESCRIPTION
This came from me realising that we used Aotearoa in the ACEFA title but not in the description of the consortium. I've replaced New Zealand with Aotearoa New Zealand in the text everywhere I saw it.

It is possible that this has messed up formatting/text flow/etc? Hope not!